### PR TITLE
Update YOLOv8 class 

### DIFF
--- a/micromind/networks/yolo.py
+++ b/micromind/networks/yolo.py
@@ -554,7 +554,9 @@ class YOLOv8(nn.Module):
     def __init__(self, w, r, d, num_classes=80):
         super().__init__()
         self.net = Darknet(w, r, d)
-        self.fpn = Yolov8Neck(w, r, d)
+        self.fpn = Yolov8Neck(
+            filters=[int(256 * w), int(512 * w), int(512 * w * r)], d=d
+        )
         self.head = DetectionHead(
             num_classes, filters=(int(256 * w), int(512 * w), int(512 * w * r))
         )

--- a/recipes/object_detection/train.py
+++ b/recipes/object_detection/train.py
@@ -98,7 +98,9 @@ class YOLO(mm.MicroMind):
         temp = """The layers you selected are not valid. \
             Please choose only layers between which the spatial resolution \
             doubles every time. Eventually, you can achieve this by \
-            changing the downsampling layers."""
+            changing the downsampling layers. If you are trying to change \
+            the input resolution, make sure you also change it in the \
+            dataset configuration file and that it is a multiple of 4."""
 
         assert up == [2, 2], " ".join(temp.split())
 


### PR DESCRIPTION
With the previous implementation the YOLOv8 class wasn't working as expected since the Neck has changed wrt the the original implementation. Now it's ok.
Already tested with the inference script and the ultralytics weights.
Exportability still missing but don't think it's a problem as of now.
Ready to be reviewed.