### PR TITLE
Added conditional layer for extracting flattened feature vector before classification layer to the Phinet and Xinet networks.

### DIFF
--- a/micromind/networks/phinet.py
+++ b/micromind/networks/phinet.py
@@ -810,9 +810,7 @@ class PhiNet(nn.Module):
             block_id += 1
 
         if self.flattened_embeddings:
-
             flatten = nn.Sequential(nn.AdaptiveAvgPool2d((1, 1)), nn.Flatten())
-
             self._layers.append(flatten)
 
         self.num_features = _make_divisible(int(block_filters * alpha), divisor=divisor)


### PR DESCRIPTION
# Description

Phinet and Xinet networks are modified to expose a conditional layer, that will return the flattened feature vector before the classification stage for when the classification head is not needed. Furthermore a new variable "features_dim" is added in the class to facilitate access to the size of the feature vector at runtime.

Also implemented the fixes from issue #85 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

- [X] Ran both Phinet and Xinet with solo learn 
- [X] Run image classification test on CIFAR10 both for Xinet and Phinet.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings