### PR TITLE
fixed double logged train loss and boolean parser

### DIFF
--- a/micromind/core.py
+++ b/micromind/core.py
@@ -527,7 +527,6 @@ class MicroMind(ABC):
                 self.accelerator.backward(loss)
                 self.opt.step()
 
-                loss_epoch += loss.item()
                 if hasattr(self, "lr_sched"):
                     # ok for cos_lr
                     self.lr_sched.step()

--- a/micromind/utils/helpers.py
+++ b/micromind/utils/helpers.py
@@ -31,8 +31,7 @@ def override_conf(hparams: Dict):
     """
     parser = argparse.ArgumentParser(description="MicroMind experiment configuration.")
     for key, value in hparams.items():
-        parser.add_argument(f"--{key}", type=type(value), default=value)
-
+        parser.add_argument(f"--{key}", type=str2bool if isinstance(value, bool) else type(value), default=value) 
     args, extra_args = parser.parse_known_args()
     for key, value in vars(args).items():
         if value is not None:
@@ -78,3 +77,14 @@ def get_logger():
     logger.add(sys.stderr, format=fmt)
 
     return logger
+
+
+def str2bool(v):
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise argparse.ArgumentTypeError('Boolean value expected.')

--- a/micromind/utils/helpers.py
+++ b/micromind/utils/helpers.py
@@ -31,7 +31,11 @@ def override_conf(hparams: Dict):
     """
     parser = argparse.ArgumentParser(description="MicroMind experiment configuration.")
     for key, value in hparams.items():
-        parser.add_argument(f"--{key}", type=str2bool if isinstance(value, bool) else type(value), default=value) 
+        parser.add_argument(
+            f"--{key}",
+            type=str2bool if isinstance(value, bool) else type(value),
+            default=value,
+        )
     args, extra_args = parser.parse_known_args()
     for key, value in vars(args).items():
         if value is not None:
@@ -82,9 +86,9 @@ def get_logger():
 def str2bool(v):
     if isinstance(v, bool):
         return v
-    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+    if v.lower() in ("yes", "true", "t", "y", "1"):
         return True
-    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+    elif v.lower() in ("no", "false", "f", "n", "0"):
         return False
     else:
-        raise argparse.ArgumentTypeError('Boolean value expected.')
+        raise argparse.ArgumentTypeError("Boolean value expected.")


### PR DESCRIPTION
# 1. train loss was logged twice at training time.
The bug was not creating any malfunctioning in the training process, but the train loss was read as double its actual amount in the `train_log.txt'.
# 2. Boolean parser was not working properly
Boolean parameters can now be passed in the form:
`python train.py --<numeric_parameter>=256 --<boolean_parameter_true>=True --<boolean_parameter_false>=False --<boolean_parameter_true>=1 --<boolean_parameter_false>=0 --<boolean_parameter_true>=y --<boolean_parameter_false>=n`
and will be processed correctly. Before, any value passed was evaluated as True